### PR TITLE
Refactor settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
-    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@tsconfig/svelte": "^1.0.10",
@@ -33,7 +32,7 @@
     "chai": "^4.3.4",
     "mocha": "^8.3.2",
     "moment": "^2.29.1",
-    "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+    "obsidian": "obsidianmd/obsidian-api#master",
     "prettier": "^2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "rollup": "^2.32.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,28 +1,28 @@
 import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
 import svelte from "rollup-plugin-svelte";
 import autoPreprocess from "svelte-preprocess";
 import copy from "rollup-plugin-copy";
+import { env } from "process";
 
 export default {
   input: 'src/index.ts',
   output: {
     file: 'dist/main.js',
-    sourcemap: 'inline',
     format: 'cjs',
     exports: 'default'
   },
-  external: ['obsidian'],
+  external: ['obsidian', "path"],
   plugins: [
-    json(),
-    typescript(),
+    typescript({ sourceMap: env.env === "DEV" }),
     resolve({
       browser: true,
       dedupe: ["svelte"],
     }),
-    commonjs(),
+    commonjs({
+      include: "node_modules/**"
+    }),
     svelte({
       preprocess: autoPreprocess(),
     }),

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -11,8 +11,8 @@ export class ReadwiseApi {
     }
 
     async getDocumentsWithHighlights(
-        since: number,
-        to: number
+        since?: number,
+        to?: number
     ): Promise<Result<Document[], Error>> {
         const documentsResult = await this.getUpdatedDocuments(since, to);
         if (documentsResult.isErr()) {
@@ -42,8 +42,8 @@ export class ReadwiseApi {
     }
 
     async getUpdatedDocuments(
-        since: number,
-        to: number
+        since?: number,
+        to?: number
     ): Promise<Result<Document[], Error>> {
         let url = `https://readwise.io/api/v2/books/`;
         const params = {
@@ -52,13 +52,13 @@ export class ReadwiseApi {
 
         let moment = (window as any).moment;
 
-        if (since !== undefined) {
+        if (this.isValidTimestamp(since)) {
             Object.assign(params, {
                 updated__gt: moment(since).utc().format(),
             });
         }
 
-        if (to !== undefined) {
+        if (this.isValidTimestamp(to)) {
             Object.assign(params, { updated__lt: moment(to).utc().format() });
         }
 
@@ -96,8 +96,8 @@ export class ReadwiseApi {
     }
 
     async getNewHighlightsInDocuments(
-        since: number,
-        to: number
+        since?: number,
+        to?: number
     ): Promise<Result<Highlight[], Error>> {
         let url = "https://readwise.io/api/v2/highlights/";
 
@@ -107,13 +107,13 @@ export class ReadwiseApi {
 
         let moment = (window as any).moment;
 
-        if (since !== undefined) {
+        if (this.isValidTimestamp(since)) {
             Object.assign(params, {
                 updated__gt: moment(since).utc().format(),
             });
         }
 
-        if (to !== undefined) {
+        if (this.isValidTimestamp(to)) {
             Object.assign(params, { updated__lt: moment(to).utc().formata() });
         }
 
@@ -146,5 +146,9 @@ export class ReadwiseApi {
         } catch (e) {
             return Result.Err(e);
         }
+    }
+
+    isValidTimestamp(timestamp?: number): boolean {
+        return timestamp !== undefined && timestamp > 0;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Notice, Plugin } from "obsidian";
-import { ObsidianReadwiseSettings, ObsidianReadwiseSettingsTab } from './settings';
+import { ObsidianReadwiseSettings } from './settings';
+import { ObsidianReadwiseSettingsTab } from './settingsTab';
 import { PluginState, StatusBar } from './status';
 import { ReadwiseApi } from './api/api';
 import type { Document } from './api/models';
@@ -84,7 +85,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		this.settings = await this.loadData() || new ObsidianReadwiseSettings();
+        this.settings = Object.assign({}, ObsidianReadwiseSettings.defaultSettings(), await this.loadData());
 	}
 
 	async saveSettings() {
@@ -155,7 +156,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
     async initializeApiWithToken(token: string): Promise<boolean> {
         const tokenPath = getTokenPath();
 
-        await this.app.vault.adapter.write(tokenPath, token, () => true);
+        await this.app.vault.adapter.write(tokenPath, token);
 
         if (token.length == 0) {
             return false;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,98 +1,15 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
-import type ObsidianReadwisePlugin from '.';
-
-
-export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
-	private plugin: ObsidianReadwisePlugin;
-
-	constructor(app: App, plugin: ObsidianReadwisePlugin) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
-
-	display(): void {
-		let {containerEl} = this;
-
-		containerEl.empty();
-
-		containerEl.createEl('h2', {text: 'Readwise Settings'});
-
-        this.apiTokenSetting();
-        this.syncOnBoot();
-        this.headerTemplate();
-        this.notificationSettings();
-	}
-
-    apiTokenSetting() {
-        const desc = document.createDocumentFragment();
-        desc.createEl("span", null, (span) => {
-            span.innerText =
-                "Specify API Token to download highlights from Readwise. You can find the token ";
-
-            span.createEl("a", null, (link) => {
-                link.href = "https://readwise.io/access_token";
-                link.innerText = "here!";
-            });
-        });
-
-		new Setting(this.containerEl)
-			.setName('Readwise API Token')
-			.setDesc(desc)
-			.addText(async (text) => {
-                try {
-                    text.setValue(await this.plugin.getApiToken())
-                }
-                catch (e) {
-                    /* Throw away read error if file does not exist. */
-                }
-
-                text.setPlaceholder('<READWISE_TOKEN>')
-				text.onChange(async (value) => {
-                    await this.plugin.initializeApiWithToken(value);
-                });
-            });
-    }
-
-    syncOnBoot() {
-        new Setting(this.containerEl)
-            .setName('Sync on Startup')
-            .setDesc('Automatically sync updated highlights when Obsidian starts')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.syncOnBoot)
-                .onChange(async (value) => {
-                    this.plugin.settings.syncOnBoot = value;
-                    await this.plugin.saveSettings();
-            }));
-    }
-
-    headerTemplate() {
-        new Setting(this.containerEl)
-            .setName('Custom Note Header Template')
-            .setDesc('Overrides the default Header for notes')
-            .addText(text => text
-                .setValue(this.plugin.settings.headerTemplate)
-                .onChange(async (value) => {
-                    this.plugin.settings.headerTemplate = value;
-                    await this.plugin.saveSettings();
-            }));
-    }
-
-    notificationSettings() {
-        new Setting(this.containerEl)
-            .setName('Disable Notifications')
-            .setDesc('Disable notifications for plugin operations to minimize distraction (refer to status bar for updates)')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.disableNotifications)
-                .onChange(async (value) => {
-                    this.plugin.settings.disableNotifications = value;
-                    await this.plugin.saveSettings();
-            }));
-    }
-}
-
 export class ObsidianReadwiseSettings {
 	syncOnBoot: boolean = false;
     lastUpdateTimestamp: number;
 	disableNotifications: boolean = false;
     headerTemplate: string;
+
+    static defaultSettings(): ObsidianReadwiseSettings {
+        return {
+            syncOnBoot: false,
+            disableNotifications: false,
+            headerTemplate: "",
+            lastUpdateTimestamp: 0
+        }
+    }
 }

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,0 +1,91 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import type ObsidianReadwisePlugin from '.';
+
+
+export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
+	private plugin: ObsidianReadwisePlugin;
+
+	constructor(app: App, plugin: ObsidianReadwisePlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		let {containerEl} = this;
+
+		containerEl.empty();
+
+		containerEl.createEl('h2', {text: 'Readwise Settings'});
+
+        this.apiTokenSetting();
+        this.syncOnBoot();
+        this.headerTemplate();
+        this.notificationSettings();
+	}
+
+    apiTokenSetting() {
+        const desc = document.createDocumentFragment();
+        desc.createEl("span", null, (span) => {
+            span.innerText =
+                "Specify API Token to download highlights from Readwise. You can find the token ";
+
+            span.createEl("a", null, (link) => {
+                link.href = "https://readwise.io/access_token";
+                link.innerText = "here!";
+            });
+        });
+
+		new Setting(this.containerEl)
+			.setName('Readwise API Token')
+			.setDesc(desc)
+			.addText(async (text) => {
+                try {
+                    text.setValue(await this.plugin.getApiToken())
+                }
+                catch (e) {
+                    /* Throw away read error if file does not exist. */
+                }
+
+                text.setPlaceholder('<READWISE_TOKEN>')
+				text.onChange(async (value) => {
+                    await this.plugin.initializeApiWithToken(value);
+                });
+            });
+    }
+
+    syncOnBoot() {
+        new Setting(this.containerEl)
+            .setName('Sync on Startup')
+            .setDesc('Automatically sync updated highlights when Obsidian starts')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.syncOnBoot)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncOnBoot = value;
+                    await this.plugin.saveSettings();
+            }));
+    }
+
+    headerTemplate() {
+        new Setting(this.containerEl)
+            .setName('Custom Note Header Template')
+            .setDesc('Overrides the default Header for notes')
+            .addText(text => text
+                .setValue(this.plugin.settings.headerTemplate)
+                .onChange(async (value) => {
+                    this.plugin.settings.headerTemplate = value;
+                    await this.plugin.saveSettings();
+            }));
+    }
+
+    notificationSettings() {
+        new Setting(this.containerEl)
+            .setName('Disable Notifications')
+            .setDesc('Disable notifications for plugin operations to minimize distraction (refer to status bar for updates)')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.disableNotifications)
+                .onChange(async (value) => {
+                    this.plugin.settings.disableNotifications = value;
+                    await this.plugin.saveSettings();
+            }));
+    }
+}

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -7,7 +7,7 @@ describe("File Doc", () => {
     context("sanitizeName", () => {
         var fileDoc: FileDoc;
 
-        beforeEach(function() {
+        beforeEach(() => {
             fileDoc = new FileDoc({
                 id: 1,
                 title: "Hello_Worl'd-",

--- a/tests/settings.ts
+++ b/tests/settings.ts
@@ -1,0 +1,30 @@
+import "mocha";
+import { assert } from "chai";
+import { ObsidianReadwiseSettings } from '../src/settings';
+import { before } from "mocha";
+
+describe("Settings", () => {
+    context("Default Settings", () => {
+        var settings: ObsidianReadwiseSettings;
+
+        before(() => {
+            settings = ObsidianReadwiseSettings.defaultSettings();
+        });
+
+        it('sets the lastUpdate to zero', () => {
+            assert.equal(settings.lastUpdateTimestamp, 0);
+        });
+
+        it('syncOnBoot is disabled', () => {
+            assert.isFalse(settings.syncOnBoot);
+        });
+
+        it('notifications are enabled', () => {
+            assert.isFalse(settings.disableNotifications);
+        });
+
+        it('headerTemplate path is empty', () => {
+            assert.isEmpty(settings.headerTemplate);
+        });
+    });
+})


### PR DESCRIPTION
## Description

Fix #3 

## Changes

* Remove sourcemap generation by default (this reduces the final `main.js` size from ~1Mb to ~250Kb
* Split `Settings` and `SettingsTab` and add new `defaultSettings` method and tests
* Update `obsidian-api` dependency
* Remove `@rollup/plugin-json` no needed
* Small refactoring in timestamp check in API