### PR TITLE
Switch to use localStorage to manage Readwise token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download zip archive from GitHub releases page. Extract the archive into `<vault
 
 After installation, it will ask for an [API token](https://readwise.io/access_token). This is required in order to pull the highlights from Readwise into your vault.
 
-**NOTE:** The token is stored at `.obsidian/secrets/readwise_token`. I'll recommend that you exclude the `secrets` folder from any backup process (e.g: Obsidian Sync, the Obsidian Git plugin).
+**NOTE:** The token is stored using [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) and it may have conflicts if the same vault were to be open on 2 different windows.
 
 ### Templating
 

--- a/src/modals/enterApiToken/tokenModal.ts
+++ b/src/modals/enterApiToken/tokenModal.ts
@@ -1,16 +1,17 @@
 import { App, Modal } from "obsidian";
+import type { TokenManager } from "src/tokenManager";
 import EnterApiTokenModalContent from "./enterApiTokenModalContent.svelte";
 
 export default class ReadwiseApiTokenModal extends Modal {
-    public token: string;
     public waitForClose: Promise<void>;
     private resolvePromise: () => void;
     private modalContent: EnterApiTokenModalContent;
+    private tokenManager: TokenManager;
 
-    constructor(app: App) {
+    constructor(app: App, tokenManager: TokenManager) {
         super(app);
 
-        this.token = "";
+        this.tokenManager = tokenManager;
         this.waitForClose = new Promise(
             (resolve) => (this.resolvePromise = resolve)
         );
@@ -21,7 +22,7 @@ export default class ReadwiseApiTokenModal extends Modal {
             target: this.contentEl,
             props: {
                 onSubmit: (value: string) => {
-                    this.token = value;
+                    this.tokenManager.Upsert(value);
                     this.close();
                 },
             },

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -56,7 +56,7 @@ export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
             .setName('Sync on Startup')
             .setDesc('Automatically sync updated highlights when Obsidian starts')
             .addToggle(toggle => toggle
-                .setValue(this.settings.syncOnBoot)
+                .setValue(this.plugin.settings.syncOnBoot)
                 .onChange(async (value) => {
                     this.plugin.settings.syncOnBoot = value;
                     await this.plugin.saveSettings();

--- a/src/tokenManager.ts
+++ b/src/tokenManager.ts
@@ -1,0 +1,16 @@
+export class TokenManager {
+
+    localStorage: any;
+
+    constructor() {
+        this.localStorage = (window as any).localStorage;
+    }
+
+    Get(): string {
+        return this.localStorage.getItem('readwise_token');
+    }
+
+    Upsert(token: string) {
+        this.localStorage.setItem('readwise_token', token);
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,0 @@
-const path = require("path");
-
-export function getSecretsDirPath(): string {
-    return path.join('.obsidian', 'secrets')
-}
-
-export function getTokenPath(): string {
-    return path.join(getSecretsDirPath(), 'readwise_token');
-}


### PR DESCRIPTION
## Description

Fix #2 

This PR moves away from storing the token in plaintext in the `.obsidian` folder (thus eliminating the need to exclude the token file from any backup process) and instead leverages the `localStorage` API

## Changes

- New `TokenManager` class to add/update token
- Simplify API initialization process
- Add API initialization process and check when running `sync` command