### PR TITLE
Set initial timestamp on plugin install

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
                 if (!(await this.initializeApi())) {
                     return;
                 }
-                await this.syncReadwise(this.settings.lastUpdateTimestamp);
+                await this.syncReadwise(this.settings.lastUpdate);
         }});
 
         if (!(await this.initializeApi())) {
@@ -60,7 +60,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
         }
 
 		if (this.settings.syncOnBoot) {
-			await this.syncReadwise(this.settings.lastUpdateTimestamp);
+			await this.syncReadwise(this.settings.lastUpdate);
 		}
 	}
 
@@ -69,7 +69,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
 	}
 
 	async loadSettings() {
-        this.settings = Object.assign({}, ObsidianReadwiseSettings.defaultSettings(), await this.loadData());
+        this.settings = ObsidianReadwiseSettings.withData(await this.loadData());
 	}
 
 	async saveSettings() {
@@ -93,7 +93,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
             await this.updateNotes(documents);
         }
 
-        this.settings.lastUpdateTimestamp = Date.now();
+        this.settings.lastUpdate = Date.now();
 
         await this.saveSettings();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,15 +1,19 @@
 export class ObsidianReadwiseSettings {
 	syncOnBoot: boolean = false;
-    lastUpdateTimestamp: number;
+    lastUpdate: number;
 	disableNotifications: boolean = false;
     headerTemplate: string;
+
+    static withData(data: any): ObsidianReadwiseSettings {
+        return Object.assign({}, ObsidianReadwiseSettings.defaultSettings(), data);
+    }
 
     static defaultSettings(): ObsidianReadwiseSettings {
         return {
             syncOnBoot: false,
             disableNotifications: false,
             headerTemplate: "",
-            lastUpdateTimestamp: 0
+            lastUpdate: Date.now()
         }
     }
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -48,7 +48,7 @@ export class StatusBar {
 
         switch (state) {
             case PluginState.idle:
-                this.displayFromNow(this.plugin.settings.lastUpdateTimestamp);
+                this.displayFromNow(this.plugin.settings.lastUpdate);
                 break;
             case PluginState.checking:
                 this.statusBarEl.setText("readwise: checking if there are new highlights to sync");

--- a/tests/settings.ts
+++ b/tests/settings.ts
@@ -4,15 +4,16 @@ import { ObsidianReadwiseSettings } from '../src/settings';
 import { before } from "mocha";
 
 describe("Settings", () => {
-    context("Default Settings", () => {
+    context("defaultSettings", () => {
         var settings: ObsidianReadwiseSettings;
 
         before(() => {
             settings = ObsidianReadwiseSettings.defaultSettings();
         });
 
-        it('sets the lastUpdate to zero', () => {
-            assert.equal(settings.lastUpdateTimestamp, 0);
+        it('sets the lastUpdate to now timestamp', () => {
+            assert.isNumber(settings.lastUpdate);
+            assert.isAbove(settings.lastUpdate, 0);
         });
 
         it('syncOnBoot is disabled', () => {
@@ -25,6 +26,34 @@ describe("Settings", () => {
 
         it('headerTemplate path is empty', () => {
             assert.isEmpty(settings.headerTemplate);
+        });
+    });
+
+    context("withData", () => {
+        var settings: ObsidianReadwiseSettings;
+        before(() => {
+            settings = ObsidianReadwiseSettings.withData({
+                lastUpdate: 10,
+                syncOnBoot: true,
+                headerTemplate: 'Hello World',
+                disableNotifications: true
+            });
+        });
+
+        it('overrides the lastUpdate field', () => {
+            assert.equal(settings.lastUpdate, 10);
+        });
+
+        it('overrides the syncOnBoot field', () => {
+            assert.isTrue(settings.syncOnBoot);
+        });
+
+        it('overrides the headerTemplate field', () => {
+            assert.equal(settings.headerTemplate, "Hello World");
+        });
+
+        it('overrides the disableNotifications field', () => {
+            assert.isTrue(settings.disableNotifications);
         });
     });
 })


### PR DESCRIPTION
## Description

Fix #13 

This eliminates the possibility of syncing all existing highlights from Readwise on first installation

## Changes

* Add tests for merging default setting with loaded data