### PR TITLE
Remove NodeJS path api

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^4.3.4",
     "mocha": "^8.3.2",
     "moment": "^2.29.1",
-    "obsidian": "obsidianmd/obsidian-api#master",
+    "obsidian": "^0.11.13",
     "prettier": "^2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "rollup": "^2.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-readwise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Sync Readwise highlights into your notes",
   "repository": {
     "type": "git",

--- a/src/fileSystem/handler.ts
+++ b/src/fileSystem/handler.ts
@@ -1,0 +1,30 @@
+import * as obsidian from "obsidian";
+import type { IFileSystemHandler } from "./interface";
+
+export class FileSystemHandler implements IFileSystemHandler {
+    adapter: obsidian.FileSystemAdapter;
+
+    constructor(adapter: obsidian.FileSystemAdapter) {
+        this.adapter = adapter;
+    }
+
+    public getBasePath(): string {
+        return this.adapter.getBasePath();
+    }
+
+    public normalizePath(path: string): string {
+        return obsidian.normalizePath(path);
+    }
+
+    public async read(path: string): Promise<string> {
+        return await this.adapter.read(path);
+    }
+
+    public async write(path: string, data: string): Promise<void> {
+        await this.adapter.write(path, data);
+    }
+
+    public async exists(path: string): Promise<boolean> {
+        return await this.adapter.exists(path);
+    }
+}

--- a/src/fileSystem/index.ts
+++ b/src/fileSystem/index.ts
@@ -1,0 +1,2 @@
+export type { IFileSystemHandler as IFileSystemHandler } from "./interface";
+export { FileSystemHandler as FileSystemHandler } from "./handler";

--- a/src/fileSystem/interface.ts
+++ b/src/fileSystem/interface.ts
@@ -1,0 +1,11 @@
+export interface IFileSystemHandler {
+    getBasePath(): string;
+
+    normalizePath(path: string): string;
+
+    read(path: string): Promise<string>;
+
+    write(path: string, data: string): Promise<void>;
+
+    exists(path: string): Promise<boolean>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin } from "obsidian";
+import { Notice, Plugin, FileSystemAdapter } from "obsidian";
 import { ObsidianReadwiseSettings, ObsidianReadwiseSettingsGenerator } from './settings';
 import { ObsidianReadwiseSettingsTab } from './settingsTab';
 import { PluginState, StatusBar } from './status';
@@ -112,10 +112,11 @@ export default class ObsidianReadwisePlugin extends Plugin {
 
     async updateNotes(documents: Document[]) {
         this.setState(PluginState.syncing)
-        const template = new Template(this.settings.headerTemplate, this.app);
+        const adapter = this.app.vault.adapter as FileSystemAdapter
+        const template = new Template(this.settings.headerTemplate, adapter);
 
         documents.forEach(doc => {
-            const fileDoc = new FileDoc(doc, template, this.app);
+            const fileDoc = new FileDoc(doc, template, adapter);
 
             fileDoc.createOrUpdate();
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type { Result } from "./result";
 import { Template } from "./template";
 import { FileDoc } from "./fileDoc";
 import { TokenManager } from "./tokenManager";
+import { FileSystemHandler } from "./fileSystem";
 
 
 export default class ObsidianReadwisePlugin extends Plugin {
@@ -112,11 +113,11 @@ export default class ObsidianReadwisePlugin extends Plugin {
 
     async updateNotes(documents: Document[]) {
         this.setState(PluginState.syncing)
-        const adapter = this.app.vault.adapter as FileSystemAdapter
-        const template = new Template(this.settings.headerTemplate, adapter);
+        const handler = new FileSystemHandler(this.app.vault.adapter as FileSystemAdapter);
+        const template = new Template(this.settings.headerTemplate, handler);
 
         documents.forEach(doc => {
-            const fileDoc = new FileDoc(doc, template, adapter);
+            const fileDoc = new FileDoc(doc, template, handler);
 
             fileDoc.createOrUpdate();
         });

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,16 +1,16 @@
 import type { Document } from "./api/models";
 import nunjucks from "nunjucks";
-import type { FileSystemAdapter } from "obsidian";
 import Log from "./log";
+import type { IFileSystemHandler } from "./fileSystem";
 
 export class Template {
 
     templatePath: string
-    fsAdapter: FileSystemAdapter
+    fsHandler: IFileSystemHandler
 
-    constructor(templatePath: string, fsAdapter: FileSystemAdapter) {
+    constructor(templatePath: string, handler: IFileSystemHandler) {
         this.templatePath = templatePath;
-        this.fsAdapter = fsAdapter;
+        this.fsHandler = handler;
     }
 
     public async templatize(doc: Document): Promise<string> {
@@ -20,7 +20,7 @@ export class Template {
                 this.templatePath += '.md'
             }
             Log.debug(`Loading template from ${this.templatePath}`)
-            template = await this.fsAdapter.read(this.templatePath);
+            template = await this.fsHandler.read(this.templatePath);
         }
 
         Log.debug("Evaluating template with doc")

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,16 +1,16 @@
 import type { Document } from "./api/models";
 import nunjucks from "nunjucks";
-import type { App } from "obsidian";
+import type { FileSystemAdapter } from "obsidian";
 import Log from "./log";
 
 export class Template {
 
     templatePath: string
-    app: App
+    fsAdapter: FileSystemAdapter
 
-    constructor(templatePath: string, app: App) {
+    constructor(templatePath: string, fsAdapter: FileSystemAdapter) {
         this.templatePath = templatePath;
-        this.app = app;
+        this.fsAdapter = fsAdapter;
     }
 
     public async templatize(doc: Document): Promise<string> {
@@ -20,7 +20,7 @@ export class Template {
                 this.templatePath += '.md'
             }
             Log.debug(`Loading template from ${this.templatePath}`)
-            template = await this.app.vault.adapter.read(this.templatePath);
+            template = await this.fsAdapter.read(this.templatePath);
         }
 
         Log.debug("Evaluating template with doc")

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -2,8 +2,17 @@ import "mocha";
 import { assert } from "chai";
 import { FileDoc } from '../src/fileDoc';
 import { Template } from "../src/template";
+import type { IFileSystemHandler } from "../src/fileSystem";
 
 describe("File Doc", () => {
+    const handler: IFileSystemHandler = {
+        getBasePath: () => "/base",
+        normalizePath: (path: string) => path,
+        read: async (path: string) => "",
+        write: async (path: string) => {},
+        exists: async (path: string) => true
+    }
+
     context("sanitizeName", () => {
         var fileDoc: FileDoc;
 
@@ -19,8 +28,8 @@ describe("File Doc", () => {
                 highlights_url: '',
                 category: 'article'
             },
-            new Template(null, null),
-            null
+            new Template(null, handler),
+            handler
             );
         });
 
@@ -44,6 +53,31 @@ describe("File Doc", () => {
             fileDoc.doc.title = "Hello/World";
 
             assert.equal(fileDoc.sanitizeName(), 'Hello-World')
+        });
+    });
+
+    context('filePath', () => {
+        let fileDoc: FileDoc;
+
+        beforeEach(() => {
+            fileDoc = new FileDoc({
+                id: 1,
+                title: "Hello World",
+                author: 'Rene Hernandez',
+                num_highlights: 2,
+                highlights: null,
+                source_url: '',
+                updated: "2021-03-18",
+                highlights_url: '',
+                category: 'article'
+            },
+            new Template(null, handler),
+            handler
+            );
+        });
+
+        it("generates the fileDoc path", () => {
+            assert.equal(fileDoc.filePath(), "/base/Hello World.md");
         });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "types": ["node", "svelte"]
     },
     "include": [
-        "src/**/*"
+        "src/**/*.ts"
     ],
     "exclude": ["node_modules/*"]
 }


### PR DESCRIPTION
## Description

Fix #18 

## Changes

- Introduces new `IFileSystemHandler` interface to abstract the usage of the obsidian `FileSystemAdapter` object and the `normalizePath` function
- Update `FileDoc` and `Template` objects to receive `IFileSystemHandler` as a dependency instead of the obsidian `FileSystemAdapter` object
- Add tests for `filePath` function within the `FileDoc` object