### PR TITLE
Improve name and description for custom template header

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The available parameters for the templates are:
 
 - `Readwise API Token`: Add/update your Readwise API token.
 - `Sync on startup`: If enabled, will sync highlights from Readwise when Obsidian starts
-- `Custom Note Header Template`: Path to override default template for Readwise notes
+- `Custom Note Header Template Path`: Path to override default template for Readwise notes
 - `Disable Notifications`: Toggle for pop-up notifications
 
 ### Commands

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -70,8 +70,8 @@ export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
 
     headerTemplate() {
         new Setting(this.containerEl)
-            .setName('Custom Note Header Template')
-            .setDesc('Overrides the default Header for notes')
+            .setName('Custom Note Header Template Path')
+            .setDesc('Path to template note that overrides the default Header')
             .addText(text => text
                 .setValue(this.plugin.settings.headerTemplate)
                 .onChange(async (value) => {


### PR DESCRIPTION
## Description

From #25 I found out that the setting is not describing properly that it refers to a path, instead of a textbox to introduce the template directly in