### PR TITLE
Fixes nunjucks autoescaping html char and incorrect path location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          BUILD: production
 
       - name: Test
         run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          BUILD: production
 
       - name: Create release
         id: create_release

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,18 +4,18 @@ import commonjs from '@rollup/plugin-commonjs';
 import svelte from "rollup-plugin-svelte";
 import autoPreprocess from "svelte-preprocess";
 import copy from "rollup-plugin-copy";
-import { env } from "process";
 
 export default {
   input: 'src/index.ts',
   output: {
     file: 'dist/main.js',
     format: 'cjs',
-    exports: 'default'
+    exports: 'default',
+    sourcemap: process.env.BUILD === "development" ? "inline" : false
   },
-  external: ['obsidian', "path"],
+  external: ['obsidian'],
   plugins: [
-    typescript({ sourceMap: env.env === "DEV" }),
+    typescript({ sourceMap: process.env.BUILD === "development" }),
     resolve({
       browser: true,
       dedupe: ["svelte"],

--- a/src/fileDoc.ts
+++ b/src/fileDoc.ts
@@ -44,7 +44,7 @@ export class FileDoc {
     }
 
     public filePath(): string {
-        return this.fsHandler.normalizePath(`${this.fsHandler.getBasePath()}/${this.sanitizeName()}.md`);
+        return this.fsHandler.normalizePath(`${this.sanitizeName()}.md`);
     }
 
     public sanitizeName(): string {

--- a/src/fileSystem/handler.ts
+++ b/src/fileSystem/handler.ts
@@ -8,10 +8,6 @@ export class FileSystemHandler implements IFileSystemHandler {
         this.adapter = adapter;
     }
 
-    public getBasePath(): string {
-        return this.adapter.getBasePath();
-    }
-
     public normalizePath(path: string): string {
         return obsidian.normalizePath(path);
     }

--- a/src/fileSystem/interface.ts
+++ b/src/fileSystem/interface.ts
@@ -1,6 +1,4 @@
 export interface IFileSystemHandler {
-    getBasePath(): string;
-
     normalizePath(path: string): string;
 
     read(path: string): Promise<string>;

--- a/src/template/loader.ts
+++ b/src/template/loader.ts
@@ -21,7 +21,9 @@ export class TemplateLoader {
     async load(): Promise<nunjucks.Template> {
         let content = await this.selectTemplate();
 
-        return nunjucks.compile(content);
+        let env = nunjucks.configure({ autoescape: false });
+
+        return nunjucks.compile(content, env);
     }
 
     async selectTemplate(): Promise<string> {

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -73,7 +73,7 @@ describe("File Doc", () => {
         });
 
         it("generates the fileDoc path", () => {
-            assert.equal(fileDoc.filePath(), "/base/Hello World.md");
+            assert.equal(fileDoc.filePath(), "Hello World.md");
         });
     });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -7,7 +7,6 @@ const path = require('path');
 
 export function fileSystemHandler(): IFileSystemHandler {
     return {
-        getBasePath: () => "/base",
         normalizePath: (path: string) => path,
         read: async (path: string) => {
             return fs.readFileSync(path).toString();

--- a/tests/templates.ts
+++ b/tests/templates.ts
@@ -123,29 +123,29 @@ describe("HighlightTemplateRenderer", () => {
             highlight = new Highlight({
                 id: 10,
                 book_id: 5,
-                text: 'Looks important',
-                note: 'It really looks important',
+                text: "Looks important. It's super <great>",
+                note: "It really looks important. Can't wait for it",
                 url: 'https://readwise.io',
                 location: 1,
             });
         });
 
         it('renders default template with doc', async () => {
-            assert.equal(await templateRenderer.render(highlight), `Looks important %% highlight_id: 10 %%
-Note: It really looks important
+            assert.equal(await templateRenderer.render(highlight), `Looks important. It's super <great> %% highlight_id: 10 %%
+Note: It really looks important. Can't wait for it
 `);
         });
 
         it('renders custom template with doc', async () => {
-            assert.equal(await customTemplateRenderer.render(highlight), `Looks important \`highlight_id: 10\` %% location: 1 %%
-Note: It really looks important
+            assert.equal(await customTemplateRenderer.render(highlight), `Looks important. It's super <great> \`highlight_id: 10\` %% location: 1 %%
+Note: It really looks important. Can't wait for it
 `);
         });
 
         it('adds highlight_id if not present on template', async () => {
             let customTemplateWithoutIdRenderer = await HighlightTemplateRenderer.create(resolvePathToData('Readwise Note Highlight Missing Id'), handler);
-            assert.equal(await customTemplateWithoutIdRenderer.render(highlight), `Looks important %% location: 1 %%
-Note: It really looks important
+            assert.equal(await customTemplateWithoutIdRenderer.render(highlight), `Looks important. It's super <great> %% location: 1 %%
+Note: It really looks important. Can't wait for it
 %% highlight_id: 10 %%
 `);
         });


### PR DESCRIPTION
## Description

This PR fixes how the path is normalized in relation to the obsidian-vault root. It also disables the autoescaping functionality for `nunjucks` which was replacing characters by their corresponding HTML representation

### Other changes

* Added tests to verify autoescaping functionality is disabled
* Update `rollup.config.js` to generate sourcemaps on development mode only