### PR TITLE
Change public facing name for readwise plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 
 name: CI
-on: [push]
+on:
+  push:
+    tags-ignore: ["*"]
 
 jobs:
   build:

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "obsidian-readwise",
-	"name": "Readwise",
+	"name": "Readwise Community",
 	"version": "0.0.3",
 	"minAppVersion": "0.11.9",
 	"description": "Sync Readwise highlights into your notes",


### PR DESCRIPTION
## Description

Fix #34 

This PR changes the public name of the plugin to `Readwise Community`

## Other Changes

- Restrict CI workflow from running on tags