### PR TITLE
Add explicit storagepath for notes and handle URL titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,15 @@
 *.iml
 .idea
 
-# npm
+# npm / yarn
 node_modules
 package-lock.json
+yarn.lock
 
 # build
 main.js
 *.js.map
 dist/
+
+# Development
+data.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Change plugin name to Readwise Community [\#34](https://github.com/renehernandez/obsidian-readwise/issues/34)
 - Change return type on `TryGet` [\#30](https://github.com/renehernandez/obsidian-readwise/issues/30)
 
-**Documentation:**
+**Documentation Updates:**
 
 - Add Changelog generation for releases [\#39](https://github.com/renehernandez/obsidian-readwise/pull/39)
 - README update [\#38](https://github.com/renehernandez/obsidian-readwise/pull/38)
@@ -53,7 +53,7 @@
 
 - Set initial timestamp to moment of plugin installation [\#13](https://github.com/renehernandez/obsidian-readwise/issues/13)
 
-**Documentation:**
+**Documentation Updates:**
 
 - Explain sync process in Readme [\#9](https://github.com/renehernandez/obsidian-readwise/issues/9)
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -24,15 +24,19 @@ export class ReadwiseApi {
 
         const documents = documentsResult.unwrap();
 
+        console.log(documents);
+
         const highlightsResult = await this.getNewHighlightsInDocuments(
             since,
             to
         );
+  
         if (highlightsResult.isErr()) {
             return highlightsResult.intoErr();
         }
 
         const highlights = highlightsResult.unwrap();
+        console.log(highlights);
 
         documents.forEach((doc) => {
             doc.highlights = highlights.filter(
@@ -106,28 +110,30 @@ export class ReadwiseApi {
         since?: number,
         to?: number
     ): Promise<Result<Highlight[], Error>> {
-        let url = "https://readwise.io/api/v2/highlights/";
+         let url = "https://readwise.io/api/v2/highlights/";
 
-        const params = {
-            page_size: "1000",
-        };
+         const params = {
+             page_size: "1000",
+         };
 
-        if (this.isValidTimestamp(since)) {
-            Object.assign(params, {
-                updated__gt: this.dateFactory
-                    .createHandler(since)
-                    .utc()
-                    .format(),
-            });
-        }
+         if (this.isValidTimestamp(since)) {
+             Object.assign(params, {
+                 updated__gt: this.dateFactory
+                     .createHandler(since)
+                     .utc()
+                     .format(),
+             });
+         }
 
-        if (this.isValidTimestamp(to)) {
-            Object.assign(params, {
-                updated__lt: this.dateFactory.createHandler(to).utc().format(),
-            });
-        }
+         if (this.isValidTimestamp(to)) {
+             Object.assign(params, {
+                 updated__lt: this.dateFactory.createHandler(to).utc().format(),
+             });
+         }
 
         url += "?" + new URLSearchParams(params);
+
+        Log.debug(`Requesting ${url}`);
 
         try {
             const response = await fetch(url, {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -24,8 +24,6 @@ export class ReadwiseApi {
 
         const documents = documentsResult.unwrap();
 
-        console.log(documents);
-
         const highlightsResult = await this.getNewHighlightsInDocuments(
             since,
             to
@@ -36,7 +34,6 @@ export class ReadwiseApi {
         }
 
         const highlights = highlightsResult.unwrap();
-        console.log(highlights);
 
         documents.forEach((doc) => {
             doc.highlights = highlights.filter(

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -28,7 +28,7 @@ export class ReadwiseApi {
             since,
             to
         );
-  
+
         if (highlightsResult.isErr()) {
             return highlightsResult.intoErr();
         }
@@ -107,26 +107,26 @@ export class ReadwiseApi {
         since?: number,
         to?: number
     ): Promise<Result<Highlight[], Error>> {
-         let url = "https://readwise.io/api/v2/highlights/";
+        let url = "https://readwise.io/api/v2/highlights/";
 
-         const params = {
-             page_size: "1000",
-         };
+        const params = {
+            page_size: "1000",
+        };
 
-         if (this.isValidTimestamp(since)) {
-             Object.assign(params, {
-                 updated__gt: this.dateFactory
-                     .createHandler(since)
-                     .utc()
-                     .format(),
-             });
-         }
+        if (this.isValidTimestamp(since)) {
+            Object.assign(params, {
+                updated__gt: this.dateFactory
+                    .createHandler(since)
+                    .utc()
+                    .format(),
+            });
+        }
 
-         if (this.isValidTimestamp(to)) {
-             Object.assign(params, {
-                 updated__lt: this.dateFactory.createHandler(to).utc().format(),
-             });
-         }
+        if (this.isValidTimestamp(to)) {
+            Object.assign(params, {
+                updated__lt: this.dateFactory.createHandler(to).utc().format(),
+            });
+        }
 
         url += "?" + new URLSearchParams(params);
 

--- a/src/fileDoc.ts
+++ b/src/fileDoc.ts
@@ -44,7 +44,10 @@ export class FileDoc {
     }
 
     public filePath(storagePath: string = ''): string {
-        return this.fsHandler.normalizePath(`${storagePath ? storagePath + '/' :''}${this.sanitizeName()}.md`)
+        if (storagePath.length > 0 && storagePath.slice(-1) !== '/') {
+            storagePath = storagePath + '/';
+        }
+        return this.fsHandler.normalizePath(`${storagePath}${this.sanitizeName()}.md`)
         .substring(0, 260);
     }
 
@@ -54,8 +57,7 @@ export class FileDoc {
             .replace(/(http[s]?\:\/\/)/, '')
             .replace(/\./g, '_')
             .replace(/\//g, '-')
-            .replace(/(\?.*)/, '')
-            .replace(/\|/g, '-')
+            .replace(/(\?.*)/, '') // Remove query params
             .replace(/\\/g, '-')
             .replace(/\:/g, '-')
     }

--- a/src/fileDoc.ts
+++ b/src/fileDoc.ts
@@ -48,7 +48,6 @@ export class FileDoc {
             storagePath = storagePath + '/';
         }
         return this.fsHandler.normalizePath(`${storagePath}${this.sanitizeName()}.md`)
-        .substring(0, 260);
     }
 
     public sanitizeName(): string {

--- a/src/fileDoc.ts
+++ b/src/fileDoc.ts
@@ -19,8 +19,8 @@ export class FileDoc {
         this.fsHandler = handler;
     }
 
-    public async createOrUpdate() {
-        const file = this.filePath();
+    public async createOrUpdate(storagePath: string) {
+        const file = this.filePath(storagePath);
 
         var content = '';
 
@@ -43,11 +43,20 @@ export class FileDoc {
         await this.fsHandler.write(file, content);
     }
 
-    public filePath(): string {
-        return this.fsHandler.normalizePath(`${this.sanitizeName()}.md`);
+    public filePath(storagePath: string = ''): string {
+        return this.fsHandler.normalizePath(`${storagePath ? storagePath + '/' :''}${this.sanitizeName()}.md`)
+        .substring(0, 260);
     }
 
     public sanitizeName(): string {
-        return this.doc.title.replace(/[/\\:]/, '-')
+        console.log(`Replacing ${this.doc.title}`);
+        return this.doc.title
+            .replace(/(http[s]?\:\/\/)/, '')
+            .replace(/\./g, '_')
+            .replace(/\//g, '-')
+            .replace(/(\?.*)/, '')
+            .replace(/\|/g, '-')
+            .replace(/\\/g, '-')
+            .replace(/\:/g, '-')
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,8 +101,8 @@ export default class ObsidianReadwisePlugin extends Plugin {
 
         this.setState(PluginState.idle);
         let message = documents.length > 0
-            ? `Readwise: Synced new changes. ${documents.length} files synced`
-            : `Readwise: Everything up-to-date`;
+            ? `Readwise: Synced new changes. ${documents.length} files synced.`
+            : `Readwise: Everything up-to-date.`;
         this.displayMessage(message);
 	}
 
@@ -121,7 +121,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
         documents.forEach(doc => {
             const fileDoc = new FileDoc(doc, header, highlight, handler);
 
-            fileDoc.createOrUpdate();
+            fileDoc.createOrUpdate(this.settings.highlightStoragePath);
         });
 
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ export interface ObsidianReadwiseSettings {
     lastUpdate: number;
 	disableNotifications: boolean;
     headerTemplatePath: string;
+    highlightStoragePath: string;
     highlightTemplatePath: string;
 }
 
@@ -18,6 +19,7 @@ export class ObsidianReadwiseSettingsGenerator {
             disableNotifications: false,
             headerTemplatePath: "",
             highlightTemplatePath: "",
+            highlightStoragePath: "",
             lastUpdate: Date.now()
         }
     }

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -22,6 +22,7 @@ export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
 
         this.apiTokenSetting();
         this.syncOnBoot();
+        this.highlightStoragePath();
         this.headerTemplatePath();
         this.highlightTemplatePath();
         this.notificationSettings();
@@ -67,6 +68,18 @@ export class ObsidianReadwiseSettingsTab extends PluginSettingTab {
                     this.plugin.settings.syncOnBoot = value;
                     await this.plugin.saveSettings();
             }));
+    }
+
+    highlightStoragePath() {
+        new Setting(this.containerEl)
+        .setName('Highlight storage path')
+        .setDesc('Path to the directory used to store the notes')
+        .addText(text => text
+            .setValue(this.plugin.settings.highlightStoragePath)
+            .onChange(async (value) => {
+                this.plugin.settings.highlightStoragePath = value;
+                await this.plugin.saveSettings();
+            }))
     }
 
     headerTemplatePath() {

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -78,8 +78,17 @@ describe("File Doc", () => {
             );
         });
 
-        it("generates the fileDoc path", () => {
+        it("generates the fileDoc path if unspecified", () => {
             assert.equal(fileDoc.filePath(), "Hello World.md");
         });
+
+        it("generates a specified fileDoc path", () => {
+            assert.equal(fileDoc.filePath('foo/bar'), "foo/bar/Hello World.md");
+        });
+
+        it("Handles trailing slash in a specified fileDoc path", () => {
+            assert.equal(fileDoc.filePath('foo/bar/'), "foo/bar/Hello World.md");
+        });
+
     });
 });

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -22,9 +22,9 @@ describe("File Doc", () => {
                 highlights_url: '',
                 category: 'article'
             },
-            await HeaderTemplateRenderer.create(null, handler),
-            await HighlightTemplateRenderer.create(null, handler),
-            handler
+                await HeaderTemplateRenderer.create(null, handler),
+                await HighlightTemplateRenderer.create(null, handler),
+                handler
             );
         });
 
@@ -48,6 +48,12 @@ describe("File Doc", () => {
             fileDoc.doc.title = "Hello/World";
 
             assert.equal(fileDoc.sanitizeName(), 'Hello-World')
+        });
+
+        it("Removes query params, slashes and protocol from URL", () => {
+            fileDoc.doc.title = "https://example.com/2021-04-26/article-name-12?foo=bar&key=value";
+
+            assert.equal(fileDoc.sanitizeName(), "example_com-2021-04-26-article-name-12");
         });
     });
 

--- a/tests/fileDoc.ts
+++ b/tests/fileDoc.ts
@@ -50,10 +50,14 @@ describe("File Doc", () => {
             assert.equal(fileDoc.sanitizeName(), 'Hello-World')
         });
 
-        it("Removes query params, slashes and protocol from URL", () => {
+        it("Removes query params, slashes and protocol from URL (http and https)", () => {
             fileDoc.doc.title = "https://example.com/2021-04-26/article-name-12?foo=bar&key=value";
 
             assert.equal(fileDoc.sanitizeName(), "example_com-2021-04-26-article-name-12");
+    
+            fileDoc.doc.title = "http://example.com/2021-04-26/article-name-13?foo=bar&key=value";
+
+            assert.equal(fileDoc.sanitizeName(), "example_com-2021-04-26-article-name-13");      
         });
     });
 


### PR DESCRIPTION
Thanks for providing this plugin! I've been wanting to write something like this for a long time but didn't get time to do it.

There were two things I missed during my initial setup:

- Some integrations of Readwise set the `title` to a URL, and the plugin didn't play nice with these cases
- I have an explicit path that I want to have my highlights in

I did this change rather quickly, happy to change/improve it based on feedback!

Fix #22 