### PR TITLE
Restrict status bar loading to desktop mode only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,9 @@ export default class ObsidianReadwisePlugin extends Plugin {
 
 	async onload() {
         let statusBarEl = this.addStatusBarItem();
-        this.statusBar = new StatusBar(statusBarEl, this, new DateFactory());
+        if (!this.app.isMobile) {
+            this.statusBar = new StatusBar(statusBarEl, this, new DateFactory());
+        }
         this.tokenManager = new TokenManager();
 
         await this.loadSettings();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,13 +20,13 @@ export default class ObsidianReadwisePlugin extends Plugin {
 	public intervalID: number;
 
 	private state: PluginState = PluginState.idle;
-	private statusBar: StatusBar;
     private api: ReadwiseApi;
+    private mode: AppMode;
 
 
     setState(state: PluginState) {
         this.state = state;
-        this.statusBar.display();
+        this.mode.display();
     }
 
     getState(): PluginState {
@@ -34,20 +34,14 @@ export default class ObsidianReadwisePlugin extends Plugin {
     }
 
 	async onload() {
-        let statusBarEl = this.addStatusBarItem();
-        if (!this.app.isMobile) {
-            this.statusBar = new StatusBar(statusBarEl, this, new DateFactory());
-        }
         this.tokenManager = new TokenManager();
+        this.mode = this.app.isMobile ? new MobileMode(this) : new DesktopMode(this);
+        this.mode.onload();
 
         await this.loadSettings();
 
         this.setState(PluginState.idle);
         this.addSettingTab(new ObsidianReadwiseSettingsTab(this.app, this));
-
-		this.registerInterval(
-            window.setInterval(() => this.statusBar.display(), 1000)
-        );
 
 		this.addCommand({
             id: "sync",
@@ -87,7 +81,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
             const error = documentsResults.unwrapErr();
 
             Log.error({message: error.message, context: error});
-            this.displayError(`Unexpected error: ${error.message}`);
+            this.mode.displayError(`Unexpected error: ${error.message}`);
             return 0;
         }
 
@@ -105,7 +99,7 @@ export default class ObsidianReadwisePlugin extends Plugin {
         let message = documents.length > 0
             ? `Readwise: Synced new changes. ${documents.length} files synced`
             : `Readwise: Everything up-to-date`;
-        this.displayMessage(message);
+        this.mode.displayMessage(message);
 	}
 
     async getNewHighlightsInDocuments(since?: number, to?: number): Promise<Result<Document[], Error>> {
@@ -149,24 +143,80 @@ export default class ObsidianReadwisePlugin extends Plugin {
         this.api = new ReadwiseApi(token, new DateFactory());
         return true
     }
+}
 
-	//#region displaying / formatting messages
-	displayMessage(message: string, timeout: number = 4 * 1000): void {
-		this.statusBar.displayMessage(message.toLowerCase(), timeout);
+interface AppMode {
+    onload(): void;
+    display(): void;
+    displayMessage(message: string): void;
+    displayError(message: string): void;
+}
 
-		if (!this.settings.disableNotifications) {
+class DesktopMode implements AppMode {
+    private statusBar: StatusBar;
+    private plugin: ObsidianReadwisePlugin;
+
+    constructor(plugin: ObsidianReadwisePlugin) {
+        this.plugin = plugin;
+    }
+
+    onload() {
+        this.statusBar = new StatusBar(this.plugin.addStatusBarItem(), this.plugin, new DateFactory());
+        this.plugin.registerInterval(
+            window.setInterval(() => this.statusBar.display(), 1000)
+        );
+    }
+
+    display(): void {
+        this.statusBar.display();
+    }
+
+    displayMessage(message: string): void {
+        if (!this.plugin.settings.disableNotifications) {
+			new Notice(message);
+		}
+
+		this.statusBar.displayMessage(message.toLowerCase(), 4 * 1000);
+
+		Log.debug(message);
+	}
+
+    displayError(message: string): void {
+        new Notice(message);
+
+        this.statusBar.displayMessage(message.toLowerCase(), 0);
+
+        Log.debug(message)
+    }
+}
+
+
+class MobileMode implements AppMode {
+    private plugin: ObsidianReadwisePlugin;
+
+    constructor(plugin: ObsidianReadwisePlugin) {
+        this.plugin = plugin;
+    }
+
+    onload() {
+        return;
+    }
+
+    display(): void {
+        return;
+    }
+
+    displayMessage(message: string): void {
+		if (!this.plugin.settings.disableNotifications) {
 			new Notice(message);
 		}
 
 		Log.debug(message);
 	}
 
-	displayError(message: string, timeout: number = 0): void {
+    displayError(message: string): void {
         new Notice(message);
-        this.statusBar.displayMessage(message.toLowerCase(), timeout);
 
         Log.debug(message)
     }
-
-	//#endregion
 }

--- a/src/obsidianTypes.ts
+++ b/src/obsidianTypes.ts
@@ -1,0 +1,7 @@
+declare module "obsidian" {
+    interface App {
+        isMobile: boolean;
+    }
+}
+
+export {}


### PR DESCRIPTION
## Description

Fix #44 

Based on the information provided by @shabegom, status bar is not present on the mobile app. This PR in turns split the handling of message on the `statusBar` object to a new `DesktopMode` entity.

## Other Changes

In order to detect whether it is running on mobile or desktop, I had to extend the obsidian `typings` to include a non-documented `app.isMobile` functionality.  Based it on https://github.com/shabegom/buttons/blob/e93643614f5f5c4490e2a9f1e66fa365bd7c5660/src/types.ts