### PR TITLE
Update the cache name to account for the job id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           path: |
             ./dist
-          key: dist-${{ env.CI_REF_NAME_SLUG }}
+          key: dist-${{ env.CI_REF_NAME_SLUG }}-${{ env.CI_RUN_NUMBER }}
 
   changelog:
     name: Update Changelog
@@ -71,7 +71,7 @@ jobs:
         with:
           path: |
             ./dist
-          key: dist-${{ env.CI_REF_NAME_SLUG }}
+          key: dist-${{ env.CI_REF_NAME_SLUG }}-${{ env.CI_RUN_NUMBER }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Description

Uniquely identify caches based on a combination tag + job id

This resolves the issue of having to delete and recreate a git tag and being unable to change the cache content